### PR TITLE
Links MESH_DEFAULT_ADDRESS to NETWORK_DEFAULT_ADDRESS

### DIFF
--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -327,7 +327,8 @@ bool RF24Mesh::requestAddress(uint8_t level){
    
     #ifdef MESH_DEBUG_SERIAL
 	Serial.print( millis() ); Serial.print(F(" MSH: Got poll from level ")); Serial.print(level);
-    Serial.print(F(" count "));Serial.println(pollCount);
+    Serial.print(F(" count "));Serial.print(pollCount);
+    Serial.print(F(" node "));Serial.println(contactNode[pollCount]); // #ML#
 	#elif defined MESH_DEBUG_PRINTF
 	printf("%u MSH: Got poll from level %d count %d\n",millis(),level,pollCount);
     #endif	
@@ -601,6 +602,7 @@ void RF24Mesh::DHCP(){
         header.type = NETWORK_ADDR_RESPONSE;
         header.to_node = header.from_node;
         //This is a routed request to 00
+        //delay(10);
         if(header.from_node != MESH_DEFAULT_ADDRESS){ //Is NOT node 01 to 05
           delay(2);
           if( network.write(header,&newAddress,sizeof(newAddress)) ){

--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -602,7 +602,7 @@ void RF24Mesh::DHCP(){
         header.type = NETWORK_ADDR_RESPONSE;
         header.to_node = header.from_node;
         //This is a routed request to 00
-        //delay(10);
+        delay(10); // ML: without this delay, address renewal fails
         if(header.from_node != MESH_DEFAULT_ADDRESS){ //Is NOT node 01 to 05
           delay(2);
           if( network.write(header,&newAddress,sizeof(newAddress)) ){

--- a/RF24Mesh_config.h
+++ b/RF24Mesh_config.h
@@ -20,7 +20,7 @@
 
 /** Other Configuration */
 #define MESH_MIN_SAVE_TIME 30000 /** Minimum time required before changing nodeID. Prevents excessive writing to EEPROM */
-#define MESH_DEFAULT_ADDRESS 04444
+#define MESH_DEFAULT_ADDRESS NETWORK_DEFAULT_ADDRESS
 #define MESH_MAX_ADDRESSES 255 /** Determines the max size of the array used for storing addresses on the Master Node */
 //#define MESH_ADDRESS_HOLD_TIME 30000 /** How long before a released address becomes available */ 
 


### PR DESCRIPTION
Changing the MESH_DEFAULT_ADDRESS in RF24Mesh_config.h fails, as in RF24Network.cpp the network default address is hardcoded in two places. See also https://github.com/nRF24/RF24/issues/288 and my pull request on RF24Network https://github.com/nRF24/RF24Network/pull/116.