### PR TITLE
Split increment and assignment in order to avoid UB

### DIFF
--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -253,8 +253,10 @@ uint16_t RF24Mesh::renewAddress(uint32_t timeout){
   while(!requestAddress(reqCounter)){
     if(millis()-start > timeout){ return 0; }
     delay(50 + ( (totalReqs+1)*(reqCounter+1)) * 2);
-    (++reqCounter) = reqCounter%4;
-    (++totalReqs) = totalReqs%10;
+    reqCounter++;
+    reqCounter = reqCounter%4;
+    totalReqs++;
+    totalReqs = totalReqs%10;
     
   }
   network.networkFlags &= ~2;


### PR DESCRIPTION
According to the [C11 standard](https://port70.net/~nsz/c/c11/n1570.html#6.5p2), the previous code could generate an undefined behavior, and would also generate a warning if compiled using clang:

```
make
clang++ -Wall -fPIC  -c RF24Mesh.cpp
RF24Mesh.cpp:256:6: warning: unsequenced modification and access to 'reqCounter' [-Wunsequenced]
    (++reqCounter) = reqCounter%4;
     ^               ~~~~~~~~~~
RF24Mesh.cpp:257:6: warning: unsequenced modification and access to 'totalReqs' [-Wunsequenced]
    (++totalReqs) = totalReqs%10;
     ^              ~~~~~~~~~
2 warnings generated.
```

 Splitting the increment and assign into multiple lines solves that, whilst improving readability and eliminating the warnings thrown by clang (which means that the code now compiles with no warnings at all under it!).