### PR TITLE
deploy docs using gh-pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,37 @@
+name: DoxyGen build
+
+on:
+  pull_request:
+  push:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-doxygen:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: get latest release version number
+      id: latest_ver
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository: nRF24/RF24Mesh
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: overwrite doxygen tags
+      run: |
+        mkdir docs
+        touch doxygenAction
+        echo "PROJECT_NUMBER = ${{ steps.latest_ver.outputs.release }}" >> doxygenAction
+        echo "@INCLUDE = doxygenAction" >> Doxyfile
+    - name: build doxygen
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+          working-directory: '.'
+          doxyfile-path: './Doxyfile'
+    - name: upload to github pages
+      if: ${{ github.event_name == 'release'}}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -2,9 +2,17 @@ name: DoxyGen build
 
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
   release:
-    types: [published, edited]
+    branches:
+      - master
+    types:
+      - published
+      - edited
 
 jobs:
   build-doxygen:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Generated library files
 *.so
 *.so.1
+
+# ignore docs folder
+docs/

--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "../../ArduinoBuilds/RF24Mesh Docs"
+OUTPUT_DIRECTORY       = ./docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -2578,3 +2578,4 @@ GENERATE_LEGEND        = YES
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_CLEANUP            = YES
+

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ RF24Mesh
 ========
 Mesh Networking for RF24Network
 
-https://tmrh20.github.io/RF24Mesh
+https://nRF24.github.io/RF24Mesh

--- a/RF24Mesh.h
+++ b/RF24Mesh.h
@@ -10,23 +10,23 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/** 
- * Network/Mesh Response Types  
- * The network will determine whether to automatically acknowledge payloads based on their type 
+/**
+ * Network/Mesh Response Types
+ * The network will determine whether to automatically acknowledge payloads based on their type
  * RF24Mesh uses pre-defined system types for interacting with RF24Network at the system level
- * 
+ *
  */
 
-// Network ACK types 
+// Network ACK types
 // None defined
 
 // No Network ACK types
 #define MESH_ADDR_LOOKUP 196
 #define MESH_ADDR_RELEASE 197
 #define MESH_ID_LOOKUP 198
- 
+
 #define MESH_BLANK_ID 65535
- 
+
 /**
  * @file RF24Mesh.h
  *
@@ -60,7 +60,6 @@ class RF24Network;
 
 class RF24Mesh
 {
-  /**@}*/
   /**
    * @name RF24Mesh
    *
@@ -82,26 +81,26 @@ public:
    */
 
   RF24Mesh( RF24& _radio,RF24Network& _network );
-  
+
   /**
    * Call this in setup() to configure the mesh and request an address.  <br>
-   *  
+   *
    * @code mesh.begin(); @endcode
-   * This may take a few moments to complete. 
-   * 
+   * This may take a few moments to complete.
+   *
    * The following parameters are optional:
    * @param channel The radio channel (1-127) default:97
    * @param data_rate The data rate (RF24_250KBPS,RF24_1MBPS,RF24_2MBPS) default:RF24_1MBPS
    * @param timeout How long to attempt address renewal in milliseconds default:7500
    */
   bool begin(uint8_t channel = MESH_DEFAULT_CHANNEL, rf24_datarate_e data_rate = RF24_1MBPS, uint32_t timeout=MESH_RENEWAL_TIMEOUT );
-  
+
   /**
    * Very similar to network.update(), it needs to be called regularly to keep the network
    * and the mesh going.
-   */   
+   */
   uint8_t update();
-  
+
   /**
    * Automatically construct a header and send a payload
    * Very similar to the standard network.write() function, which can be used directly.
@@ -109,7 +108,7 @@ public:
    * @note Including the nodeID parameter will result in an automatic address lookup being performed.
    * @note Message types 1-64 (decimal) will NOT be acknowledged by the network, types 65-127 will be. Use as appropriate to manage traffic:
    * if expecting a response, no ack is needed.
-   * 
+   *
    * @param data Send any type of data of any length (Max length determined by RF24Network layer)
    * @param msg_type The user-defined (1-127) message header_type to send. Used to distinguish between different types of data being transmitted.
    * @param size The size of the data being sent
@@ -117,17 +116,17 @@ public:
    * @return True if success, False if failed
    */
   bool write(const void* data, uint8_t msg_type, size_t size, uint8_t nodeID=0);
-  
+
   /**
-   * Set a unique nodeID for this node.  
-   * 
-   * This needs to be called before mesh.begin(), can be via serial connection, eeprom etc if configuring a large number of nodes...  
+   * Set a unique nodeID for this node.
+   *
+   * This needs to be called before mesh.begin(), can be via serial connection, eeprom etc if configuring a large number of nodes...
    * @note If using RF24Gateway and/or RF24Ethernet, nodeIDs 0 & 1 are used by the master node.
-   * @param nodeID Can be any unique value ranging from 1 to 253 
+   * @param nodeID Can be any unique value ranging from 1 to 253
    */
   void setNodeID(uint8_t nodeID);
 
-  
+
   /**
   * Reconnect to the mesh and renew the current RF24Network address. Used to re-establish a connection to the mesh if physical location etc. has changed, or
   * a routing node goes down.
@@ -136,20 +135,20 @@ public:
   * @note If all nodes are set to verify connectivity/reconnect at a specified period, restarting the master (and deleting dhcplist.txt on Linux) will result
   * in complete network/mesh reconvergence.
   * @param timeout How long to attempt address renewal in milliseconds default:7500
-  
+
   * @return Returns the newly assigned RF24Network address
   */
   uint16_t renewAddress(uint32_t timeout=MESH_RENEWAL_TIMEOUT);
-  
+
   #if !defined(MESH_NOMASTER)
  /**
   * Only to be used on the master node. Provides automatic configuration for sensor nodes, similar to DHCP.
   * Call immediately after calling network.update() to ensure address requests are handled appropriately
-  */  
+  */
   void DHCP();
-  
+
   #endif
-  
+
   /**@}*/
   /**
    * @name Advanced Operation
@@ -157,35 +156,35 @@ public:
    *  For advanced configuration and usage of the mesh
    */
   /**@{*/
-  
+
   /**
    * Convert an RF24Network address into a nodeId.
    * @param address If no address is provided, returns the local nodeID, otherwise a lookup request is sent to the master node
    * @return Returns the unique identifier (1-255) or -1 if not found.
    */
   int16_t getNodeID(uint16_t address=MESH_BLANK_ID);
-  
+
   /**
    * Tests connectivity of this node to the mesh.
    * @note If this function fails, address renewal should typically be done.
    * @return Return 1 if connected, 0 if mesh not responding
    */
-  
+
   bool checkConnection();
-  
+
   /**
    * Releases the currently assigned address lease. Useful for nodes that will be sleeping etc.
    * @note Nodes should ensure that addresses are released successfully prior to going offline.
    * @return Returns 1 if successfully released, 0 if not
    */
   bool releaseAddress();
-  
+
   /**
    * The assigned RF24Network (Octal) address of this node
    * @return Returns an unsigned 16-bit integer containing the RF24Network address in octal format
    */
-  uint16_t mesh_address; 
-  
+  uint16_t mesh_address;
+
   /**
    * Convert a nodeID into an RF24Network address
    * @note If printing or displaying the address, it needs to be converted to octal format: Serial.println(address,OCT);
@@ -201,23 +200,23 @@ public:
    *
    */
   bool write(uint16_t to_node, const void* data, uint8_t msg_type, size_t size );
-  
+
   /**
   * Change the active radio channel after the mesh has been started.
   */
   void setChannel(uint8_t _channel);
-  
+
   /**
   * Allow child nodes to discover and attach to this node.
   * @param allow True to allow children, False to prevent children from attaching automatically.
   */
   void setChild(bool allow);
-  
+
   /**
   * RF24Mesh ID and Address lookups as well as address renewal can take some time.
   * Set a callback function to enable additional processing while the mesh is working
-  * 
-  * @code 
+  *
+  * @code
   * void myCallbackFunction(){
   *   someValue = someOtherValue;
   * }
@@ -227,9 +226,9 @@ public:
   * @param meshCallback The name of a function to call
   */
   void setCallback( void (*meshCallback)(void) );
-  
+
   #define MESH_CALLBACK if(meshCallback){ meshCallback(); }
-  
+
   #if !defined(MESH_NOMASTER)
   /**
   * Set/change a nodeID/RF24Network Address pair manually on the master node.
@@ -237,13 +236,13 @@ public:
   * @code
   * Set a static address for node 02, with nodeID 23, since it will just be a static routing node for example
   * running on an ATTiny chip.
-  * 
+  *
   * mesh.setAddress(23,02);
   * @endcode
   *
   * @code
   * Change/set the nodeID for an existing address
-  * 
+  *
   * uint16_t address = 012;
   * mesh.setAddress(3,address,true);
   * @endcode
@@ -251,27 +250,27 @@ public:
   * @param nodeID The nodeID to assign
   * @param address The octal RF24Network address to assign
   * @param searchBy Optional parameter. Default is search by nodeID and set the address. True allows searching by address and setting nodeID.
-  * @return If the nodeID exists in the list, 
+  * @return If the nodeID exists in the list,
   */
-  void setAddress(uint8_t nodeID, uint16_t address, bool searchBy = false);  
-  
+  void setAddress(uint8_t nodeID, uint16_t address, bool searchBy = false);
+
   void saveDHCP();
   void loadDHCP();
-  
+
   /**
    * @name Deprecated
    *
    *  Methods provided for backwards compabibility with old/testing code.
    */
   /**@{*/
-  
+
   /**
    * Calls setAddress()
    */
   void setStaticAddress(uint8_t nodeID, uint16_t address);
-  
+
   #endif
-  
+
   /**@}*/
   /**
    * @name Address list struct
@@ -283,21 +282,21 @@ public:
   /**@}*/
 
   uint8_t _nodeID;
-  
+
 #if !defined(MESH_NOMASTER)
   typedef struct{
 	uint8_t nodeID;       /**< NodeIDs and addresses are stored in the addrList array using this structure */
 	uint16_t address;  /**< NodeIDs and addresses are stored in the addrList array using this structure */
   }addrListStruct;
-  
+
   // Pointer used for dynamic memory allocation of address list
   addrListStruct *addrList;  /**< See the addrListStruct class reference */
   uint8_t addrListTop;       /**< The number of entries in the assigned address list */
 #endif
-  
+
   private:
   RF24& radio;
-  RF24Network& network;  
+  RF24Network& network;
 
   void (*meshCallback)(void);
   bool requestAddress(uint8_t level); /**< Actual requesting of the address once a contact node is discovered or supplied **/
@@ -312,10 +311,10 @@ public:
   uint8_t getLevel(uint16_t address); /**< Returns the number of digits in the specified address **/
 
  };
- 
+
  #endif
- 
- 
+
+
  /**
   * @example RF24Mesh_Example.ino
   * <b> Arduino Example Sketch </b><br>
@@ -324,7 +323,7 @@ public:
   * The nodes will refresh their network address as soon as a single write fails. This allows the
   * nodes to change position in relation to each other and the master node.
   */
-  
+
  /**
   * @example RF24Mesh_Example_Master.ino
   * <b> Arduino Example Sketch </b><br>
@@ -343,30 +342,30 @@ public:
   * @example RF24Mesh_Example_Node2Node.ino
   * Example of node to node communication using RF24Mesh
   */
-  
+
   /**
   * @example RF24Mesh_Example_Node2NodeExtra.ino
   * Extended Example of node to node communication using RF24Mesh
   */
-  
+
  /**
   * @example RF24Mesh_SerialConfig.ino
-  * 
+  *
   * This example sketch shows how the same sketch can be written to a large number of devices, which are
-  * configured later via Serial input. 
+  * configured later via Serial input.
   *
   */
- 
+
   /**
   * @example RF24Mesh_Example.cpp
-  * 
+  *
   * <b> Raspberry Pi Example Sketch </b><br>
   * This example sketch shows how to manually configure a node via RF24Mesh, and send data to the
   * master node.
   * The nodes will refresh their network address as soon as a single write fails. This allows the
   * nodes to change position in relation to each other and the master node.
   */
-  
+
  /**
   * @example RF24Mesh_Example_Master.cpp
   *
@@ -380,13 +379,13 @@ public:
   * in a manner similar to DHCP.
   *
   */
-  
+
   /**
   * @example RF24Mesh_Ncurses_Master.cpp
   * A very limited ncurses interface used for initial monitoring/testing of RF24Mesh
   * <img src="tmrh20/RF24Mesh_Ncurses.JPG">
   */
-  
+
 /**
  * @mainpage Mesh Networking Layer for RF24 Radios
  *
@@ -398,12 +397,12 @@ public:
  * @section Purpose Purpose/Goals
  *
  * - Provide a simple user interface for creating dynamic sensor networks with the RF24 and RF24Network libraries.
- * - Create stable, fully automated/self-managed networks 
+ * - Create stable, fully automated/self-managed networks
  *
  * @section Overview RF24Mesh Overview
  * The RF24Network library provides a system of addressing and routing for RF24 radio modules that allows large wireless sensor networks to be constructed. <br> RF24Mesh
- * provides extended features, including automatic addressing and dynamic configuration of wireless sensors. 
- * 
+ * provides extended features, including automatic addressing and dynamic configuration of wireless sensors.
+ *
  * **How does it work?**<br>
  *
  * Nodes are assigned a unique number ranging from 1 to 253, and just about everything else, addressing, routing, etc. is managed by the library.
@@ -413,7 +412,7 @@ public:
  *
  * The 'master' node keeps track of the unique nodeIDs and the assigned RF24Network addresses. When a node is moved physically, or just loses its connection to the network,
  * it can automatically re-join the mesh and reconfigure itself within the network.
- 
+
  * In the mesh configuration sensors/nodes can move around physically, far from the 'master node' using other nodes to route traffic over extended distances. Addressing and
  * topology is reconfigured as connections are broken and re-established within different areas of the network.
  *
@@ -430,10 +429,10 @@ public:
  * @li Improvements to address renewal, connection verification and lookups
  *
  * @section More How to learn more
- * 
+ *
  * @li Try it out!
  * @li <a href="Setup-Config.html">Setup and Configuration</a>
- * @li <a href="General-Usage.html">Usage & Overview </a> 
+ * @li <a href="General-Usage.html">Usage & Overview </a>
  * @li <a href="classRF24Mesh.html">RF24Mesh Class Documentation</a>
  * @li <a href="http://tmrh20.github.io/RF24Network/">RF24 Network Class Documentation</a>
  * @li <a href="http://tmrh20.github.io/RF24Ethernet/">RF24Ethernet: TCP/IP based Mesh over RF24</a>
@@ -453,12 +452,12 @@ public:
  * @li 1 or more Arduino,RPi,etc. (Sensor Nodes)  <br>
  * @li 2 or more NRF24L01+ radio modules  <br>
  * @li 1 or more various sensors for your sensor nodes  <br>
- *  
+ *
  * <b>Software Requirements:</b>
  * @li <a href="https://github.com/TMRh20/RF24/archive/master.zip">RF24 Core Radio Library</a>
  * @li <a href="https://github.com/TMRh20/RF24Network/archive/master.zip">RF24Network Library</a>
  * @li <a href="https://github.com/TMRh20/RF24Mesh/archive/master.zip">RF24Mesh - Dynamic Mesh Library</a>
- *  
+ *
  * @section Installation Installation
  * 1. Use the Arduino Library Manager. Selecting RF24Mesh should also install RF24Network and RF24 Core libraries  <br>
  *  <br>
@@ -471,39 +470,39 @@ public:
  *    b: <b>RPi:</b> Run 'make' from the examples directory. Then 'sudo ./RF24Mesh_Example_Master' to begin as the master node   <br>
  *    <br>
  * 4. Once configured and running, the Master Node will begin to assign addresses to the sensor nodes, which will find their way onto the network, and
- *    display incoming data from the sensor examples. Usage is very much the same as RF24Network, except for address assignment and network management.  
+ *    display incoming data from the sensor examples. Usage is very much the same as RF24Network, except for address assignment and network management.
  *
  * @section Config Configuration
  *
  * As per the examples, nodes are configured with a unique value between 1 and 253. This allows them to change positions on the network while still being identified. <br>
  *
  * For pre-configuration of the mesh, some options are available by editing RF24Mesh_config.h prior to compiling: <br>
- * 
- * @code  
- * #define MESH_MAX_CHILDREN 4  
+ *
+ * @code
+ * #define MESH_MAX_CHILDREN 4
  * @endcode
  * The max_children option restricts the maximum number of child nodes/node and limits the number of available addresses on the network. Max: 4 <br>
  *
- * @code  
- * #define MESH_NOMASTER  
+ * @code
+ * #define MESH_NOMASTER
  * @endcode
  * The nomaster option reduces program space and memory usage. Can be used on any node except for the master (nodeID 0) <br>
  *
- * 
+ *
  * @li See <a href="General-Usage.html">General Usage</a> for information on how to work with the mesh once connected.
- * 
+ *
  * @page General-Usage General Usage
- * 
+ *
  * @section Net_Design Network Design Options
- * 
- * 1. **Static Network** (No Mesh): 
+ *
+ * 1. **Static Network** (No Mesh):
  * RF24Network can be configured manually, with a static design. RF24Mesh is not used at all. See http://tmrh20.github.io/RF24Network/Addressing.html <br><br>
  *
  * 2. **Static Network w/Dynamic Assignment:**
- * RF24Mesh is only used to acquire an address on startup. Nodes are generally expected to remain stationary. Changes to 
+ * RF24Mesh is only used to acquire an address on startup. Nodes are generally expected to remain stationary. Changes to
  * the network would be addressed manually, by adding, removing, or resetting nodes. Users can choose to use RF24Network functions directly, or use RF24Mesh. <br><br>
  *
- * 3. **Dynamic Network & Assignment:** 
+ * 3. **Dynamic Network & Assignment:**
  * Nodes join the mesh automatically and re-attach as required. This is the default and how the examples work. <br><br>
  *
  * 4. **Hybrid Network**:
@@ -513,47 +512,47 @@ public:
  * @section NetMgmt Network Management
  *
  * RF24Network addresses can be viewed as MAC addresses, and RF24Mesh nodeIDs viewed as static IP addresses. When joining or re-attaching to the network, nodes
- * will request a RF24Network address, and are identified via nodeID. 
+ * will request a RF24Network address, and are identified via nodeID.
  *
  * **Raspberry Pi/Linux:** On Linux devices, the RF24Gateway will save address assignments to file (dhcplist.txt) so they will be restored, even if the
  * gateway is restarted. To force network re-convergence, delete the dhcplist.txt file and restart the gateway. If nodes are configured to verify their connection at a set
- * interval, they will come back online in time. 
+ * interval, they will come back online in time.
  *
  * **Arduino/AVR:** On all other devices, the address list is not saved. To force network re-convergence, restart the gateway. If nodes are configured to verify their
  * connection at a set interval, they will come back online in time.
  *
- * If a node/nodeID is removed from the network permanently, the address should be released prior to removal. If it is not, the assigned RF24Network address can be 
+ * If a node/nodeID is removed from the network permanently, the address should be released prior to removal. If it is not, the assigned RF24Network address can be
  * written to 0 in the RF24Mesh address list.
- * 
+ *
  * @section MeshComm Mesh Communication
  *
  * RF24Mesh nodeIDs are unique identifiers, while RF24Network addresses change dynamically within a statically defined structure. Due to this structure, it is simple
- * for any node to communicate with the master node, since the RF24Network address is always known (00). Conversely, the master node maintains a list of every node on the 
- * network, so address 'lookups' return immediately. 
+ * for any node to communicate with the master node, since the RF24Network address is always known (00). Conversely, the master node maintains a list of every node on the
+ * network, so address 'lookups' return immediately.
  *
- * Communication from node-to-node requires address queries to be sent to the master node, since individual nodes may change RF24Network & radio address at any time. 
+ * Communication from node-to-node requires address queries to be sent to the master node, since individual nodes may change RF24Network & radio address at any time.
  * Due to the extra data transmissions, node-to-node communication is less efficient.
  *
  * @section General General Usage
  *
  * One thing to keep in mind is the dynamic nature of RF24Mesh, and the need to verify connectivity to the network. For nodes that are constantly transmitting,
- * (every few seconds at most) it is suitable to check the connection, and/or renew the address when connectivity fails. Since data is not saved by the master 
+ * (every few seconds at most) it is suitable to check the connection, and/or renew the address when connectivity fails. Since data is not saved by the master
  * node, if the master node goes down, all child nodes must renew their address. In this case, as long as the master node is down for a few seconds, the nodes
  * will all begin requesting an address.  <br>
- *  
+ *
  * Nodes that are not actively transmitting, should be configured to test their connection at predefined intervals, to allow them to reconnect as necessary.<br>
- *  
- * In the case of sleeping nodes, or nodes that will only be online temporarily, it is generally suitable to release the address prior to going offline, and 
+ *
+ * In the case of sleeping nodes, or nodes that will only be online temporarily, it is generally suitable to release the address prior to going offline, and
  * requesting an address upon waking. Keep in mind, address requests can generally take anywhere from 10-15ms, up to few seconds in most cases. <br>
- *   
+ *
  * One of the recently introduced features is the ability to transmit payloads without the network returning a network-ack response. If solely using this method
  * of transmission, the node should also be configured to verify its connection via mesh.checkConnection(); periodically, to ensure connectivity.
- * 
+ *
  * @section RF24Network RF24Network
- * 
+ *
  * Beyond requesting and releasing addresses, usage is outlined in the class documentation, and further information regarding RF24Network is available at
  * http://tmrh20.github.io/RF24Network
  *
  *
- * 
+ *
  */

--- a/RF24Mesh.h
+++ b/RF24Mesh.h
@@ -434,9 +434,9 @@ public:
  * @li <a href="Setup-Config.html">Setup and Configuration</a>
  * @li <a href="General-Usage.html">Usage & Overview </a>
  * @li <a href="classRF24Mesh.html">RF24Mesh Class Documentation</a>
- * @li <a href="http://tmrh20.github.io/RF24Network/">RF24 Network Class Documentation</a>
- * @li <a href="http://tmrh20.github.io/RF24Ethernet/">RF24Ethernet: TCP/IP based Mesh over RF24</a>
- * @li <a href="http://tmrh20.github.io/RF24Gateway/">RF24Gateway: A TCP/IP and RF24 Gateway for RF24 nodes</a>
+ * @li <a href="http://nRF24.github.io/RF24Network/">RF24 Network Class Documentation</a>
+ * @li <a href="http://nRF24.github.io/RF24Ethernet/">RF24Ethernet: TCP/IP based Mesh over RF24</a>
+ * @li <a href="http://nRF24.github.io/RF24Gateway/">RF24Gateway: A TCP/IP and RF24 Gateway for RF24 nodes</a>
  * @li <a href="https://tmrh20.github.io">All Documentation and Downloads</a>
  * @li <a href="https://github.com/TMRh20/RF24Mesh">Source Code</a>
  *
@@ -462,8 +462,8 @@ public:
  * 1. Use the Arduino Library Manager. Selecting RF24Mesh should also install RF24Network and RF24 Core libraries  <br>
  *  <br>
  * 2. Configure and test the hardware using examples from RF24 and RF24Network prior to attempting to use RF24Mesh  <br>
- *    a: <b>In Arduino IDE:</b> File > Examples > RF24 > GettingStarted  see: <a href="http://tmrh20.github.io/RF24/Arduino.html"> Arduino</a> <br>
- *    b: <b>RPi:</b> An installer is provided: <a href="http://tmrh20.github.io/RF24/Linux.html">Linux</a> <a href="http://tmrh20.github.io/RF24/RPi.html">RPi</a>  <br>
+ *    a: <b>In Arduino IDE:</b> File > Examples > RF24 > GettingStarted  see: <a href="http://nRF24.github.io/RF24/Arduino.html"> Arduino</a> <br>
+ *    b: <b>RPi:</b> An installer is provided: <a href="http://nRF24.github.io/RF24/Linux.html">Linux</a> <a href="http://nRF24.github.io/RF24/RPi.html">RPi</a>  <br>
  *  <br>
  * 3. Once testing is complete:  <br>
  *    a: <b>Arduino IDE:</b> File > Examples > RF24Mesh > RF24Mesh_Example  <br>
@@ -496,7 +496,7 @@ public:
  * @section Net_Design Network Design Options
  *
  * 1. **Static Network** (No Mesh):
- * RF24Network can be configured manually, with a static design. RF24Mesh is not used at all. See http://tmrh20.github.io/RF24Network/Addressing.html <br><br>
+ * RF24Network can be configured manually, with a static design. RF24Mesh is not used at all. See http://nRF24.github.io/RF24Network/Addressing.html <br><br>
  *
  * 2. **Static Network w/Dynamic Assignment:**
  * RF24Mesh is only used to acquire an address on startup. Nodes are generally expected to remain stationary. Changes to
@@ -551,7 +551,7 @@ public:
  * @section RF24Network RF24Network
  *
  * Beyond requesting and releasing addresses, usage is outlined in the class documentation, and further information regarding RF24Network is available at
- * http://tmrh20.github.io/RF24Network
+ * http://nRF24.github.io/RF24Network
  *
  *
  *

--- a/doxygen-custom.css
+++ b/doxygen-custom.css
@@ -801,4 +801,15 @@ dl.bug {
 .caption {
     font-weight: bold;
 }
+td.fielddoc
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone {
+    background-image: none;
+    border-radius: unset;
+}
 
+td.fielddoc tr:last-child {
+    border-bottom: 1px solid #2D4068;
+}

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=TMRh20,Avamander
 sentence=OSI Layer 7, Automated 'mesh' style networking for nrf24L01(+) radios.
 paragraph=Attempting to provide fully automated, wireless, mesh networking for sensor networks/IoT devices. Automated addressing, discovery and operation built on the RF24 communication stack.
 category=Communication
-url=https://tmrh20.github.io/RF24Mesh/
+url=https://nRF24.github.io/RF24Mesh/
 architectures=*
 depends=RF24,RF24Network


### PR DESCRIPTION
Introduces a new workflow that:
- only runs on master branch
- only deploys docs on release "publish" or "edit" events
- fetches latest version tag from this repo's releases and uses it to update the Doxyfile's "PROJECT_NUMBER" tag. This tag change is not committed to the Doxyfile, rather it is only used during the workflow.

Additionally, I've
- made fixes for all "addressable" doxygen warnings (`Makefile` is parsed like a C source file because there is no extension -- its a doxygen problem)
    - This includes removing deprecated tags from the Doxyfile (they were using default or invalid options anyway). I didn't use `doxygen -u` for backward compatibility reasons.
- formatted and updated the doxygen-custom.css file
- renamed all links to docs from tmrh20.github.io/\<repo name> to nRF24.github.io/\<repo name> except for:
    - the links to the automatic install/update script at [tmrh20's RF24Installer for RPi](https://github.com/TMRh20/tmrh20.github.io/tree/master/RF24Installer/RPi)
    - any links that lead to tmrh20.github.io main page listing all RF24 repos (links for this page have to be changed separately in the [tmrh20.github.io repo's index.html file](https://github.com/TMRh20/tmrh20.github.io/blob/587d08b7b1cc9185fb6bb1185fbf3f42e1546acd/index.html#L33)
- deactivated any LATEX or XML output from doxygen since they're not actually being used (and the LATEX output seems to require 3rd party software to generate properly). 