### PR TITLE
improve examples' use of mesh.begin() and renewAddress()

### DIFF
--- a/RF24Mesh.h
+++ b/RF24Mesh.h
@@ -110,7 +110,7 @@ public:
      * Set a unique @ref _nodeID "nodeID" for this node.
      *
      * This needs to be called before RF24Mesh::begin(). The parameter value passed can be fetched
-     * via serial connection, eeprom, etc when configuring a large number of nodes.
+     * via serial connection, EEPROM, etc when configuring a large number of nodes.
      * @note If using RF24Gateway and/or RF24Ethernet, nodeIDs 0 & 1 are used by the master node.
      * @param nodeID Can be any unique value ranging from 1 to 255 (reserving 0 for the master node).
      */
@@ -124,9 +124,10 @@ public:
      *
      * @note If all nodes are set to verify connectivity and reconnect at a specified period, then
      * restarting the master (and deleting dhcplist.txt on Linux) will result in complete
-     * network/mesh reconvergence.
+     * network/mesh re-convergence.
      * @param timeout How long to attempt address renewal in milliseconds. Default is 7500
-     * @return The newly assigned RF24Network address
+     * @return The newly assigned RF24Network address. If the connecting process fails, then
+     * MESH_DEFAULT_ADDRESS is returned because all consciously unconnected nodes use that address.
      */
     uint16_t renewAddress(uint32_t timeout = MESH_RENEWAL_TIMEOUT);
 

--- a/examples/RF24Mesh_Example/RF24Mesh_Example.ino
+++ b/examples/RF24Mesh_Example/RF24Mesh_Example.ino
@@ -50,9 +50,17 @@ void setup() {
   // Connect to the mesh
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
-    while (1) {
-      // hold in an infinite loop
+    if (radio.isChipConnected()) {
+      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+        Serial.println(F("Connecting to the mesh..."));
+      }
+    }
+    else {
+      Serial.println(F("Radio hardware not responding."));
+      while (1) {
+        // hold in an infinite loop
+      }
     }
   }
 }

--- a/examples/RF24Mesh_Example/RF24Mesh_Example.ino
+++ b/examples/RF24Mesh_Example/RF24Mesh_Example.ino
@@ -25,7 +25,6 @@ RF24Mesh mesh(radio, network);
  *
  * In this example, configuration takes place below, prior to uploading the sketch to the device
  * A unique value from 1-255 must be configured for each node.
- * This will be stored in EEPROM on AVR devices, so remains persistent between further uploads, loss of power, etc.
  */
 #define nodeID 1
 

--- a/examples/RF24Mesh_Example/RF24Mesh_Example.ino
+++ b/examples/RF24Mesh_Example/RF24Mesh_Example.ino
@@ -79,10 +79,10 @@ void loop() {
     if (!mesh.write(&displayTimer, 'M', sizeof(displayTimer))) {
 
       // If a write fails, check connectivity to the mesh network
-      if ( ! mesh.checkConnection() ) {
+      if (!mesh.checkConnection()) {
         //refresh the network address
         Serial.println("Renewing Address");
-        if (!mesh.renewAddress()) {
+        if (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
           //If address renewal fails, reconfigure the radio and restart the mesh
           //This allows recovery from most if not all radio errors
           mesh.begin();

--- a/examples/RF24Mesh_Example/RF24Mesh_Example.ino
+++ b/examples/RF24Mesh_Example/RF24Mesh_Example.ino
@@ -51,10 +51,10 @@ void setup() {
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
     if (radio.isChipConnected()) {
-      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+      do {
         // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
-        Serial.println(F("Connecting to the mesh..."));
-      }
+        Serial.println(F("Could not connect to network.\nConnecting to the mesh..."));
+      } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
     }
     else {
       Serial.println(F("Radio hardware not responding."));

--- a/examples/RF24Mesh_Example_Master/RF24Mesh_Example_Master.ino
+++ b/examples/RF24Mesh_Example_Master/RF24Mesh_Example_Master.ino
@@ -36,7 +36,8 @@ void setup() {
   Serial.println(mesh.getNodeID());
   // Connect to the mesh
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
+    // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+    Serial.println(F("Radio hardware not responding."));
     while (1) {
       // hold in an infinite loop
     }

--- a/examples/RF24Mesh_Example_Master_Statics/RF24Mesh_Example_Master_Statics.ino
+++ b/examples/RF24Mesh_Example_Master_Statics/RF24Mesh_Example_Master_Statics.ino
@@ -36,7 +36,8 @@ void setup() {
   Serial.println(mesh.getNodeID());
   // Connect to the mesh
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
+    // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+    Serial.println(F("Radio hardware not responding."));
     while (1) {
       // hold in an infinite loop
     }

--- a/examples/RF24Mesh_Example_Master_To_Nodes/RF24Mesh_Example_Master_To_Nodes.ino
+++ b/examples/RF24Mesh_Example_Master_To_Nodes/RF24Mesh_Example_Master_To_Nodes.ino
@@ -40,7 +40,8 @@ void setup() {
   Serial.println(mesh.getNodeID());
   // Connect to the mesh
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
+    // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+    Serial.println(F("Radio hardware not responding."));
     while (1) {
       // hold in an infinite loop
     }

--- a/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
+++ b/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
@@ -45,9 +45,17 @@ void setup() {
   // Connect to the mesh
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
-    while (1) {
-      // hold in an infinite loop
+    if (radio.isChipConnected()) {
+      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+        Serial.println(F("Connecting to the mesh..."));
+      }
+    }
+    else {
+      Serial.println(F("Radio hardware not responding."));
+      while (1) {
+        // hold in an infinite loop
+      }
     }
   }
 }

--- a/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
+++ b/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
@@ -46,10 +46,10 @@ void setup() {
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
     if (radio.isChipConnected()) {
-      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+      do {
         // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
-        Serial.println(F("Connecting to the mesh..."));
-      }
+        Serial.println(F("Could not connect to network.\nConnecting to the mesh..."));
+      } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
     }
     else {
       Serial.println(F("Radio hardware not responding."));
@@ -69,13 +69,13 @@ void loop() {
     RF24NetworkHeader header;
     uint32_t mills;
     network.read(header, &mills, sizeof(mills));
-    Serial.print("Rcv "); Serial.print(mills);
-    Serial.print(" from nodeID ");
+    Serial.print(F("Rcv ")); Serial.print(mills);
+    Serial.print(F(" from nodeID "));
     int _ID = mesh.getNodeID(header.from_node);
     if ( _ID > 0) {
       Serial.println(_ID);
     } else {
-      Serial.println("Mesh ID Lookup Failed");
+      Serial.println(F("Mesh ID Lookup Failed"));
     }
   }
 
@@ -87,12 +87,11 @@ void loop() {
     // Send an 'M' type to other Node containing the current millis()
     if (!mesh.write(&millisTimer, 'M', sizeof(millisTimer), otherNodeID)) {
       if (!mesh.checkConnection()) {
-        Serial.println("Renewing Address");
-        while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        do {
           Serial.println(F("Reconnecting to mesh network..."));
-        }
+        } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
       } else {
-        Serial.println("Send fail, Test OK");
+        Serial.println(F("Send fail, Test OK"));
       }
     }
   }

--- a/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
+++ b/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
@@ -89,7 +89,7 @@ void loop() {
       if (!mesh.checkConnection()) {
         Serial.println("Renewing Address");
         while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
-          Serial.println(F("Reconnecting to mesh network..."))
+          Serial.println(F("Reconnecting to mesh network..."));
         }
       } else {
         Serial.println("Send fail, Test OK");

--- a/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
+++ b/examples/RF24Mesh_Example_Node2Node/RF24Mesh_Example_Node2Node.ino
@@ -86,9 +86,11 @@ void loop() {
 
     // Send an 'M' type to other Node containing the current millis()
     if (!mesh.write(&millisTimer, 'M', sizeof(millisTimer), otherNodeID)) {
-      if ( ! mesh.checkConnection() ) {
+      if (!mesh.checkConnection()) {
         Serial.println("Renewing Address");
-        mesh.renewAddress();
+        while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+          Serial.println(F("Reconnecting to mesh network..."))
+        }
       } else {
         Serial.println("Send fail, Test OK");
       }

--- a/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
+++ b/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
@@ -140,7 +140,7 @@ void loop() {
       if (!mesh.checkConnection()) {
         Serial.println(F("Renewing Address"));
         while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
-          Serial.println(F("Reconnecting to mesh network..."))
+          Serial.println(F("Reconnecting to mesh network..."));
         }
       } else {
         Serial.println(F("Send fail, Test OK"));

--- a/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
+++ b/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
@@ -54,9 +54,17 @@ void setup() {
   // Connect to the mesh
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
-    while (1) {
-      // hold in an infinite loop
+    if (radio.isChipConnected()) {
+      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+        Serial.println(F("Connecting to the mesh..."));
+      }
+    }
+    else {
+      Serial.println(F("Radio hardware not responding."));
+      while (1) {
+        // hold in an infinite loop
+      }
     }
   }
 }

--- a/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
+++ b/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
@@ -138,10 +138,9 @@ void loop() {
     if (!mesh.write(&millisTimer, 'M', sizeof(millisTimer), otherNodeID)) {
       Serial.println(F("Send fail"));
       if (!mesh.checkConnection()) {
-        Serial.println(F("Renewing Address"));
-        while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        do {
           Serial.println(F("Reconnecting to mesh network..."));
-        }
+        } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
       } else {
         Serial.println(F("Send fail, Test OK"));
       }

--- a/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
+++ b/examples/RF24Mesh_Example_Node2NodeExtra/RF24Mesh_Example_Node2NodeExtra.ino
@@ -137,9 +137,11 @@ void loop() {
     // Send an 'M' type to other Node containing the current millis()
     if (!mesh.write(&millisTimer, 'M', sizeof(millisTimer), otherNodeID)) {
       Serial.println(F("Send fail"));
-      if ( ! mesh.checkConnection() ) {
+      if (!mesh.checkConnection()) {
         Serial.println(F("Renewing Address"));
-        mesh.renewAddress();
+        while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+          Serial.println(F("Reconnecting to mesh network..."))
+        }
       } else {
         Serial.println(F("Send fail, Test OK"));
       }

--- a/examples/RF24Mesh_SerialConfig/RF24Mesh_SerialConfig.ino
+++ b/examples/RF24Mesh_SerialConfig/RF24Mesh_SerialConfig.ino
@@ -48,13 +48,21 @@ void setup() {
   }
 
   // Now that this node has a unique ID, connect to the mesh
+  Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
-    Serial.println(F("Radio hardware not responding or could not connect to network."));
-    while (1) {
-      // hold in an infinite loop
+    if (radio.isChipConnected()) {
+      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+        Serial.println(F("Connecting to the mesh..."));
+      }
+    }
+    else {
+      Serial.println(F("Radio hardware not responding."));
+      while (1) {
+        // hold in an infinite loop
+      }
     }
   }
-
 }
 
 unsigned long displayTimer = 0;

--- a/examples/RF24Mesh_SerialConfig/RF24Mesh_SerialConfig.ino
+++ b/examples/RF24Mesh_SerialConfig/RF24Mesh_SerialConfig.ino
@@ -51,10 +51,10 @@ void setup() {
   Serial.println(F("Connecting to the mesh..."));
   if (!mesh.begin()) {
     if (radio.isChipConnected()) {
-      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+      do {
         // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
-        Serial.println(F("Connecting to the mesh..."));
-      }
+        Serial.println(F("Could not connect to network.\nConnecting to the mesh..."));
+      } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
     }
     else {
       Serial.println(F("Radio hardware not responding."));

--- a/examples_RPi/RF24Mesh_Example.cpp
+++ b/examples_RPi/RF24Mesh_Example.cpp
@@ -27,10 +27,10 @@ int main(int argc, char **argv)
   printf("start nodeID %d\n", mesh.getNodeID());
   if (!mesh.begin()) {
     if (radio.isChipConnected()) {
-      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+      do {
         // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
         printf("Could not connect to network.\nConnecting to the mesh...\n");
-      }
+      } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
     }
     else {
       printf("Radio hardware not responding.\n");

--- a/examples_RPi/RF24Mesh_Example.cpp
+++ b/examples_RPi/RF24Mesh_Example.cpp
@@ -26,8 +26,16 @@ int main(int argc, char **argv)
   // Connect to the mesh
   printf("start nodeID %d\n", mesh.getNodeID());
   if (!mesh.begin()) {
-    printf("Radio hardware not responding or could not connect to network.\n");
-    return 0;
+    if (radio.isChipConnected()) {
+      while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+        // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+        printf("Could not connect to network.\nConnecting to the mesh...\n");
+      }
+    }
+    else {
+      printf("Radio hardware not responding.\n");
+      return 0;
+    }
   }
   radio.printDetails();
 

--- a/examples_RPi/RF24Mesh_Example.py
+++ b/examples_RPi/RF24Mesh_Example.py
@@ -1,6 +1,7 @@
 """
 Simplest RF24Mesh example that transmits a time stamp (in milliseconds) 1 per second.
 """
+import sys
 import time
 import struct
 from RF24 import RF24, RF24_PA_MAX
@@ -24,7 +25,16 @@ mesh = RF24Mesh(radio, network)
 mesh.setNodeID(4)
 print("starting nodeID", mesh.getNodeID())
 if not mesh.begin():
-    raise OSError("Radio hardware not responding or could not connect to mesh.")
+    if not radio.isChipConnected():
+        try:
+            print("Could not connect to network.\nConnecting to mesh...")
+            while mesh.renewAddress() == 0o4444:
+                print("Could not connect to network.\nConnecting to mesh...")
+        except KeyboardInterrupt:
+            radio.powerDown()
+            sys.exit()
+    else:
+        raise OSError("Radio hardware not responding or could not connect to mesh.")
 radio.setPALevel(RF24_PA_MAX)  # Power Amplifier
 radio.printDetails()
 
@@ -43,9 +53,9 @@ try:
                 if not mesh.checkConnection():
                     # The address could be refreshed per a specified timeframe
                     # or only when sequential writes fail, etc.
-                    print("Renewing Address")
+                    print("Renewing Address...")
                     while mesh.renewAddress() == 0o4444:
-                        print("Renewing Address")
+                        print("Renewing Address...")
                 else:
                     print("Send fail, Test OK")
             else:

--- a/examples_RPi/RF24Mesh_Example.py
+++ b/examples_RPi/RF24Mesh_Example.py
@@ -44,7 +44,8 @@ try:
                     # The address could be refreshed per a specified timeframe
                     # or only when sequential writes fail, etc.
                     print("Renewing Address")
-                    mesh.renewAddress()
+                    while mesh.renewAddress() == 0o4444:
+                        print("Renewing Address")
                 else:
                     print("Send fail, Test OK")
             else:

--- a/examples_RPi/RF24Mesh_Example.py
+++ b/examples_RPi/RF24Mesh_Example.py
@@ -1,20 +1,20 @@
-#!/usr/bin/env python3
+"""
+Simplest RF24Mesh example that transmits a time stamp (in milliseconds) 1 per second.
+"""
+import time
+import struct
+from RF24 import RF24, RF24_PA_MAX
+from RF24Network import RF24Network
+from RF24Mesh import RF24Mesh
 
+start = time.monotonic()
 
-from time import sleep, time
-from struct import pack
-from RF24 import *
-from RF24Network import *
-from RF24Mesh import *
-
-start = time()
 
 def millis():
-    return int((time() - start) * 1000) % (2 ** 32)
+    """:Returns: Delta time since started example in milliseconds. Wraps value around
+    the width of a ``long`` integer."""
+    return int((time.monotonic() - start) * 1000) % (2**32)
 
-def delay(ms):
-    ms = ms % (2 ** 32)
-    sleep(ms / 1000.0)
 
 # radio setup for RPi B Rev2: CS0=Pin 24
 radio = RF24(22, 0)
@@ -22,30 +22,33 @@ network = RF24Network(radio)
 mesh = RF24Mesh(radio, network)
 
 mesh.setNodeID(4)
-print("start nodeID", mesh.getNodeID())
+print("starting nodeID", mesh.getNodeID())
 if not mesh.begin():
-    print("Radio hardware not responding or could not connect to network.")
-    exit()
-radio.setPALevel(RF24_PA_MAX) # Power Amplifier
+    raise OSError("Radio hardware not responding or could not connect to mesh.")
+radio.setPALevel(RF24_PA_MAX)  # Power Amplifier
 radio.printDetails()
 
-displayTimer = 0
+TIMER = 0
 
-while 1:
-    # Call mesh.update to keep the network updated
-    mesh.update()
+try:
+    while True:
+        # Call mesh.update to keep the network updated
+        mesh.update()
 
-    if (millis() - displayTimer) >= 1000:
-        displayTimer = millis()
+        if (millis() - TIMER) >= 1000:
+            TIMER = millis()
 
-        if not mesh.write(pack("L", displayTimer), ord('M')):
-            # If a write fails, check connectivity to the mesh network
-            if not mesh.checkConnection():
-                # The address could be refreshed per a specified timeframe or only when sequential writes fail, etc.
-                print("Renewing Address")
-                mesh.renewAddress()
+            if not mesh.write(struct.pack("L", TIMER), ord("M")):
+                # If a write fails, check connectivity to the mesh network
+                if not mesh.checkConnection():
+                    # The address could be refreshed per a specified timeframe
+                    # or only when sequential writes fail, etc.
+                    print("Renewing Address")
+                    mesh.renewAddress()
+                else:
+                    print("Send fail, Test OK")
             else:
-                print("Send fail, Test OK")
-        else:
-            print("Send OK:", displayTimer)
-    delay(1)
+                print("Send OK:", TIMER)
+        time.sleep(0.001)  # delay 1 ms
+except KeyboardInterrupt:
+    radio.powerDown()  # power radio down before exiting

--- a/examples_RPi/RF24Mesh_Example_Master.cpp
+++ b/examples_RPi/RF24Mesh_Example_Master.cpp
@@ -25,7 +25,8 @@ int main(int argc, char **argv)
   // Connect to the mesh
   printf("start\n");
   if (!mesh.begin()) {
-    printf("Radio hardware not responding or could not connect to network.\n");
+    // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+    printf("Radio hardware not responding.\n");
     return 0;
   }
   radio.printDetails();

--- a/examples_RPi/RF24Mesh_Example_Master.py
+++ b/examples_RPi/RF24Mesh_Example_Master.py
@@ -1,31 +1,32 @@
-#!/usr/bin/env python3
-
-
-from struct import unpack
-from RF24 import *
-from RF24Network import *
-from RF24Mesh import *
+"""
+Example of using the rf24_mesh module to operate the nRF24L01 transceiver as
+a Mesh network master node.
+"""
+import struct
+from RF24 import RF24, RF24_PA_MAX
+from RF24Network import RF24Network
+from RF24Mesh import RF24Mesh
 
 
 # radio setup for RPi B Rev2: CS0=Pin 24
 radio = RF24(22, 0)
 network = RF24Network(radio)
 mesh = RF24Mesh(radio, network)
-
 mesh.setNodeID(0)
 if not mesh.begin():
-    print("Radio hardware not responding or could not connect to network.")
-    exit()
-radio.setPALevel(RF24_PA_MAX) # Power Amplifier
+    # if mesh.begin() returns false for a master node,
+    # then radio.begin() returned false.
+    raise OSError("Radio hardware not responding.")
+radio.setPALevel(RF24_PA_MAX)  # Power Amplifier
 radio.printDetails()
 
-while 1:
-    mesh.update()
-    mesh.DHCP()
+try:
+    while True:
+        mesh.update()
+        mesh.DHCP()
 
-    while network.available():
-        header, payload = network.read(10)
-        if chr(header.type) == 'M':
-            print("Rcv {} from 0{:o}".format(unpack("L", payload)[0], header.from_node))
-        else:
-            print("Rcv bad type {} from 0{:o}".format(header.type, header.from_node))
+        while network.available():
+            header, payload = network.read(struct.calcsize("L"))
+            print(f"Received message {header.toString()}")
+except KeyboardInterrupt:
+    radio.powerDown()  # power radio down before exiting

--- a/examples_RPi/ncurses/RF24Mesh_Ncurses_Master.cpp
+++ b/examples_RPi/ncurses/RF24Mesh_Ncurses_Master.cpp
@@ -43,7 +43,8 @@ int main()
   printf("Establishing mesh...\n");
   mesh.setNodeID(0);
   if (!mesh.begin()) {
-    printf("Radio hardware not responding or could not connect to network.\n");
+    // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+    printf("Radio hardware not responding.\n");
     return 0;
   }
   radio.printDetails();

--- a/examples_pico/RF24Mesh_Example.cpp
+++ b/examples_pico/RF24Mesh_Example.cpp
@@ -38,10 +38,10 @@ bool setup()
     printf("start nodeID %d\n", mesh.getNodeID());
     if (!mesh.begin()) {
         if (radio.isChipConnected()) {
-            while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+            do {
                 // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
                 printf("Could not connect to network.\nConnecting to the mesh...\n");
-            }
+            } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
         }
         else {
             printf("Radio hardware not responding.\n");
@@ -64,8 +64,9 @@ void loop()
             // If a write fails, check connectivity to the mesh network
             if (!mesh.checkConnection()) {
                 // The address could be refreshed per a specified timeframe or only when sequential writes fail, etc.
-                printf("Renewing Address\n");
-                mesh.renewAddress();
+                do {
+                    printf("Renewing Address...\n");
+                } while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS);
             }
             else {
                 printf("Send fail, Test OK\n");

--- a/examples_pico/RF24Mesh_Example.cpp
+++ b/examples_pico/RF24Mesh_Example.cpp
@@ -36,10 +36,17 @@ bool setup()
 
     // Connect to the mesh
     printf("start nodeID %d\n", mesh.getNodeID());
-    if (!mesh.begin())
-    {
-        printf("Radio hardware not responding or could not connect to network.\n");
-        return 0;
+    if (!mesh.begin()) {
+        if (radio.isChipConnected()) {
+            while (mesh.renewAddress() == MESH_DEFAULT_ADDRESS) {
+                // mesh.renewAddress() will return MESH_DEFAULT_ADDRESS on failure to connect
+                printf("Could not connect to network.\nConnecting to the mesh...\n");
+            }
+        }
+        else {
+            printf("Radio hardware not responding.\n");
+            return 0;
+        }
     }
     return true;
 }

--- a/examples_pico/RF24Mesh_Example_Master.cpp
+++ b/examples_pico/RF24Mesh_Example_Master.cpp
@@ -33,7 +33,8 @@ bool setup()
     // Connect to the mesh
     printf("start\n");
     if (!mesh.begin()) {
-        printf("Radio hardware not responding or could not connect to network.\n");
+        // if mesh.begin() returns false for a master node, then radio.begin() returned false.
+        printf("Radio hardware not responding.\n");
         return 0;
     }
 


### PR DESCRIPTION
This solves #203 

While reviewing all the examples, I added some comments to the Linux C++ examples and ported the work from the mesh examples in pyrf24. I can revert the changes to the python examples if people are still using python2.7 for some reason, but I'm pretty sure boost.python has phased out maintenance support for python2.