### PR TITLE
Set Power Amp to MIN to prevent power issue while testing

### DIFF
--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -33,6 +33,7 @@ bool RF24Mesh::begin(uint8_t channel, rf24_datarate_e data_rate, uint32_t timeou
         return 0;
     radio.setChannel(channel);
     radio.setDataRate(data_rate);
+    radio.setPALevel(RF24_PA_MIN);
     network.returnSysMsgs = true;
 
     if (getNodeID() > 0) { //Not master node


### PR DESCRIPTION
Fixing #137. All communication exemple set the power to low to prevent power supply issue. It was missing in the begin() of the Mesh. I dont know if is enough to close the issue but was having the same problem and fixed it by adding that to the code.