### PR TITLE
Enhance checkConnection() function

### DIFF
--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -163,9 +163,9 @@ bool ESBMesh<network_t, radio_t>::checkConnection()
 
         int16_t result = getAddress(_nodeID);
         switch (result) {
-            case -2: return false; break; // Address not found in list or is default
-            case -1: continue; break;     // Write failed or timed out
-            case 0: return false; break;  // This is a master node
+            case -2: return false; // Address not found in list or is default
+            case -1: continue;     // Write failed or timed out
+            case 0: return false;  // This is a master node
             default:
                 if ((uint16_t)result == mesh_address) {
                     return true;

--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -167,10 +167,10 @@ bool ESBMesh<network_t, radio_t>::checkConnection()
             case -1: continue;     // Write failed or timed out
             case 0: return false;  // This is a master node
             default:
-                if ((uint16_t)result == mesh_address) {
+                if ((uint16_t)result == mesh_address) { // Successful address lookup if result == RF24Network address
                     return true;
                 }
-                break; // Successful address lookup if result == RF24Network address
+                break;
         }
     }
     return false;

--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -159,12 +159,21 @@ template<class network_t, class radio_t>
 bool ESBMesh<network_t, radio_t>::checkConnection()
 {
     // getAddress() doesn't use auto-ack; do a double-check to manually retry 1 more time
-    if (getAddress(_nodeID) < 1) {
-        if (getAddress(_nodeID) < 1) {
-            return false;
+    for (uint8_t i = 0; i < MESH_CONNECTION_CHECK_ATTEMPTS; i++) {
+
+        int16_t result = getAddress(_nodeID);
+        switch (result) {
+            case -2: return false; break; // Address not found in list or is default
+            case -1: continue; break;     // Write failed or timed out
+            case 0: return false; break;  // This is a master node
+            default:
+                if ((uint16_t)result == mesh_address) {
+                    return true;
+                }
+                break; // Successful address lookup if result == RF24Network address
         }
     }
-    return true;
+    return false;
 }
 
 /*****************************************************/

--- a/RF24Mesh_config.h
+++ b/RF24Mesh_config.h
@@ -54,6 +54,17 @@
     #define MESH_MEM_ALLOC_SIZE 10
 #endif // MESH_MEM_ALLOC_SIZE
 
+/**
+ * @brief Number of attempts to verify a connection
+ *
+ * On child nodes, when calling `mesh.checkConnection();`, configure how many attempts will be made to contact the master node to verify connectivity
+ * Raising this number can result in a more stable mesh, since nodes can more easily verify that a connection is active
+ */
+
+#ifndef MESH_CONNECTION_CHECK_ATTEMPTS
+    #define MESH_CONNECTION_CHECK_ATTEMPTS 3
+#endif
+
 /**************************/
 /***       Debug        ***/
 //#define RF24MESH_DEBUG_MINIMAL /** Uncomment for the Master Node to print out address assignments as they are assigned */

--- a/RF24Mesh_config.h
+++ b/RF24Mesh_config.h
@@ -60,7 +60,6 @@
  * On child nodes, when calling `mesh.checkConnection();`, configure how many attempts will be made to contact the master node to verify connectivity
  * Raising this number can result in a more stable mesh, since nodes can more easily verify that a connection is active
  */
-
 #ifndef MESH_CONNECTION_CHECK_ATTEMPTS
     #define MESH_CONNECTION_CHECK_ATTEMPTS 3
 #endif


### PR DESCRIPTION
- Define MESH_CONNECTION_CHECK_ATTEMPTS in RF24Mesh_config.h & add doc info

**checkConnection() function:**
- Return from `checkConnection()` if -2 received  (not in list or default address)
- retry if -1  (write failed or timed out)
- success if address matches
-  fail otherwise

This should enhance stability a bit by raising the connection check attempts to 3.

It should also enhance the actual connection check by returning immediately and not retrying if a -2 is received (not in list or default address).

Furthermore it actually verifies that the returned RF24Network address matches the existing RF24Network address.

