### PR TITLE
expose releaseAddress() for master nodes

### DIFF
--- a/RF24Mesh.cpp
+++ b/RF24Mesh.cpp
@@ -86,11 +86,7 @@ uint8_t RF24Mesh::update()
         }
         else if (type == MESH_ADDR_RELEASE) {
             uint16_t* fromAddr = (uint16_t*)network.frame_buffer;
-            for (uint8_t i = 0; i < addrListTop; i++) {
-                if (addrList[i].address == *fromAddr) {
-                    addrList[i].address = 0;
-                }
-            }
+            releaseAddress(*fromAddr);
         }
     }
 #endif //!NO_MASTER
@@ -272,6 +268,21 @@ bool RF24Mesh::releaseAddress()
     }
     return 0;
 }
+
+/*****************************************************/
+
+#ifndef MESH_NOMASTER
+bool RF24Mesh::releaseAddress(uint16_t address)
+{
+    for (uint8_t i = 0; i < addrListTop; ++i) {
+        if (addrList[i].address == address) {
+            addrList[i].address = 0;
+            return true;
+        }
+    }
+    return false;
+}
+#endif
 
 /*****************************************************/
 

--- a/RF24Mesh.h
+++ b/RF24Mesh.h
@@ -314,6 +314,18 @@ public:
     addrListStruct* addrList;
     /** @brief The number of entries in the addrListStruct of assigned addresses. */
     uint8_t addrListTop;
+
+    /**
+     * Releases the specified address if leased to a mesh node's ID.
+     *
+     * This is specific to master nodes, so network administrators can
+     * manage assigned addresses without notifying the nodes that
+     * might be appropriating them.
+     *
+     * @param address The address to release from any mesh node.
+     * @return True if successfully released, otherwise false.
+     */
+    bool releaseAddress(uint16_t address);
 #endif
     /**@}*/
 

--- a/pyRF24Mesh/pyRF24Mesh.cpp
+++ b/pyRF24Mesh/pyRF24Mesh.cpp
@@ -65,7 +65,16 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(renewAddress_overload, RF24Mesh::renewAdd
 // ******************** RF24Mesh exposed  **************************
 BOOST_PYTHON_MODULE(RF24Mesh)
 {
-    { //::RF24Mesh
+    {
+        /* Binding this class is useless unless we can properly expose RF24Mesh::addrList.
+           A converter from addrListStruct[] to bp::list<AddrListStruct> needs to be implemented.
+        // ::RF24Mesh::addrListStruct
+        bp::class_<RF24Mesh::addrListStruct>("addrListStruct", bp::init<>())
+            .def_readonly("nodeID", &RF24Mesh::addrListStruct::nodeID)
+            .def_readwrite("address", &RF24Mesh::addrListStruct::address);
+        */
+
+        //::RF24Mesh
         bp::class_<RF24Mesh>("RF24Mesh", bp::init<RF24&, RF24Network&>((bp::arg("_radio"), bp::arg("_network"))))
             //bool begin(uint8_t channel = MESH_DEFAULT_CHANNEL, rf24_datarate_e data_rate = RF24_1MBPS, uint32_t timeout=MESH_RENEWAL_TIMEOUT );
             .def("begin", &RF24Mesh::begin, begin_overload(bp::args("channel", "data_rate", "timeout")))
@@ -80,14 +89,22 @@ BOOST_PYTHON_MODULE(RF24Mesh)
             .def("setNodeID", &RF24Mesh::setNodeID, (bp::arg("nodeID")))
             //void DHCP();
             .def("DHCP", &RF24Mesh::DHCP)
-            //int16_t getNodeID(uint16_t address=MESH_BLANK_ID);
+            //int16_t getNodeID(uint16_t address);
             .def("getNodeID", &RF24Mesh::getNodeID, getNodeID_overload(bp::args("address")))
+            //int16_t getNodeID(); where address arg defaults to MESH_BLANK_ID
+            .def("getNodeID", &RF24Mesh::getNodeID, getNodeID_overload())
             //bool checkConnection();
             .def("checkConnection", &RF24Mesh::checkConnection)
-            //uint16_t renewAddress(uint32_t timeout=MESH_RENEWAL_TIMEOUT);
-            .def("renewAddress", &RF24Mesh::renewAddress, getNodeID_overload(bp::args("timeout")))
+            //uint16_t renewAddress(uint32_t timeout);
+            .def("renewAddress", &RF24Mesh::renewAddress, renewAddress_overload(bp::args("timeout")))
+            //uint16_t renewAddress(); where timeout arg defaults to MESH_RENEWAL_TIMEOUT
+            .def("renewAddress", &RF24Mesh::renewAddress, renewAddress_overload())
             //bool releaseAddress();
-            .def("releaseAddress", &RF24Mesh::releaseAddress)
+            .def("releaseAddress", (bool(RF24Mesh::*)()) & RF24Mesh::releaseAddress)
+#ifndef MESH_NOMASTER
+            //bool releaseAddress(uint16_t address);
+            .def("releaseAddress", (bool(RF24Mesh::*)(uint16_t)) & RF24Mesh::releaseAddress, (bp::args("address")))
+#endif
             //int16_t getAddress(uint8_t nodeID);
             .def("getAddress", &RF24Mesh::getAddress, (bp::arg("nodeID")))
             //void setChannel(uint8_t _channel);
@@ -100,6 +117,14 @@ BOOST_PYTHON_MODULE(RF24Mesh)
             .def("saveDHCP", &RF24Mesh::saveDHCP)
             //void loadDHCP();
             .def("loadDHCP", &RF24Mesh::loadDHCP)
+            // mesh_address
+            .def_readwrite("mesh_address", &RF24Mesh::mesh_address)
+
+            // Returning an array of wrapped addrListStruct objects in boost.python is non-trivial.
+            // I'm commenting out the members related to the RF24Mesh::addrList until a solution can be found.
+            // .def_readonly("addrListTop", &RF24Mesh::addrListTop)
+            // .def_readonly("addrList", &RF24Mesh::addrList)
+
             //void setStaticAddress(uint8_t nodeID, uint16_t address);
             .def("setStaticAddress", &RF24Mesh::setStaticAddress, (bp::arg("nodeID"), bp::arg("address")));
     }

--- a/pyRF24Mesh/setup.py
+++ b/pyRF24Mesh/setup.py
@@ -45,7 +45,6 @@ setup(
             "RF24Mesh",
             sources=["pyRF24Mesh.cpp"],
             libraries=["rf24mesh", "rf24network", "rf24", BOOST_LIB],
-            extra_compile_args=["-DRF24_NO_INTERRUPT"]
         )
     ],
 )


### PR DESCRIPTION
This backports nRF24/RF24Mesh#244 to v1.x.

I could not cherry pick the changes because there was a conflict of function declarations (about the use of templates in v2.x).